### PR TITLE
chore: fix continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
           pkg-config \
           build-essential \
           libssl-dev \
-          zlib1g-dev
+          zlib1g-dev \
+          protobuf-compiler
 
     - name: Install cargo-pgrx
       run: cargo install --locked cargo-pgrx --version "=0.14.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,27 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Cache Rust dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Cache pgrx PostgreSQL builds
+      uses: actions/cache@v4
+      with:
+        path: ~/.pgrx
+        key: ${{ runner.os }}-pgrx-pg${{ matrix.pg }}-${{ hashFiles('.github/workflows/ci.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-pgrx-pg${{ matrix.pg }}-
+
     - name: Install build dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,15 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Install PostgreSQL dependencies
+    - name: Install build dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          postgresql-server-dev-all \
           libreadline-dev \
           pkg-config \
-          build-essential
+          build-essential \
+          libssl-dev \
+          zlib1g-dev
 
     - name: Install cargo-pgrx
       run: cargo install --locked cargo-pgrx --version "=0.14.3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,17 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Install PostgreSQL dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          postgresql-server-dev-all \
+          libreadline-dev \
+          pkg-config \
+          build-essential
+
     - name: Install cargo-pgrx
-      run: cargo install cargo-pgrx --version "=0.14.3"
+      run: cargo install --locked cargo-pgrx --version "=0.14.3"
 
     - name: Initialize pgrx
       run: cargo pgrx init --pg${{ matrix.pg }} download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run clippy
-      run: cargo clippy --all --features pg${{ matrix.pg }} -- -D warnings
+      run: cargo clippy --all --no-default-features --features pg${{ matrix.pg }} -- -D warnings
 
     - name: Run tests
-      run: cargo pgrx test --features pg${{ matrix.pg }}
+      run: cargo pgrx test --no-default-features --features pg${{ matrix.pg }}
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ Cargo.lock
 
 # pgrx generated files
 /sql/
-*.control
 
 # IDE
 .vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,3 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 
 [package.metadata.pgrx]
-module_pathname = "$libdir/pg_substrait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 
 [package.metadata.pgrx]
+comment = "Substrait integration for PostgreSQL"
+relocatable = false
+superuser = false

--- a/pg_substrait.control
+++ b/pg_substrait.control
@@ -1,0 +1,5 @@
+comment = 'Substrait integration for PostgreSQL'
+default_version = '0.1.0'
+module_pathname = '$libdir/pg_substrait'
+relocatable = false
+superuser = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ unsafe fn create_int4_const(
     (*const_node).consttypmod = -1;
     (*const_node).constcollid = pg_sys::InvalidOid;
     (*const_node).constlen = 4;
-    (*const_node).constvalue = pg_sys::Int32GetDatum(value);
+    (*const_node).constvalue = pg_sys::Datum::from(value);
     (*const_node).constisnull = false;
     (*const_node).constbyval = true;
 
@@ -197,7 +197,7 @@ unsafe fn create_int8_const(
     (*const_node).consttypmod = -1;
     (*const_node).constcollid = pg_sys::InvalidOid;
     (*const_node).constlen = 8;
-    (*const_node).constvalue = pg_sys::Int64GetDatum(value);
+    (*const_node).constvalue = pg_sys::Datum::from(value);
     (*const_node).constisnull = false;
     (*const_node).constbyval = true;
 
@@ -216,7 +216,7 @@ unsafe fn create_text_const(
     (*const_node).consttypmod = -1;
     (*const_node).constcollid = pg_sys::DEFAULT_COLLATION_OID;
     (*const_node).constlen = -1;
-    (*const_node).constvalue = pg_sys::PointerGetDatum(text_datum as *mut std::ffi::c_void);
+    (*const_node).constvalue = pg_sys::Datum::from(text_datum as *mut std::ffi::c_void);
     (*const_node).constisnull = false;
     (*const_node).constbyval = false;
 


### PR DESCRIPTION
- Now includes necessary postgres dependencies
- Postgres build is cached (until the workflow changes) for performance
- pg_substrait.control is now manually provided