### PR TITLE
Support PostgreSQL 16, 17, and 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # The project supports PostgreSQL 17 only (see Cargo.toml features).
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [16, 17, 18]
     steps:
     - uses: actions/checkout@v4
 
@@ -37,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.pgrx
-        key: ${{ runner.os }}-pgrx-pg17-${{ env.PGRX_VERSION }}
+        key: ${{ runner.os }}-pgrx-pg${{ matrix.pg }}-${{ env.PGRX_VERSION }}
 
     - name: Install build dependencies
       run: |
@@ -73,7 +76,7 @@ jobs:
     - name: Initialize pgrx
       run: |
         if [ ! -e ~/.pgrx/config.toml ]; then
-          cargo pgrx init --pg17 download
+          cargo pgrx init --pg${{ matrix.pg }} download
         else
           echo "pgrx already initialized from cache"
         fi
@@ -82,10 +85,10 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Run clippy
-      run: cargo clippy --all --features pg17 -- -D warnings
+      run: cargo clippy --all --no-default-features --features pg${{ matrix.pg }} -- -D warnings
 
     - name: Run tests
-      run: cargo pgrx test pg17
+      run: cargo pgrx test pg${{ matrix.pg }} --no-default-features
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@
 ## Technical Notes
 - Use manual `ExecInitNode` initialization instead of `ExecutorStart` when constructing plans programmatically.
 - Use PostgreSQL API calls instead of hardcoded values when constructing plan nodes.
-- Support only PostgreSQL 17 (pg17), not multiple versions.
+- Support PostgreSQL 16 through 18 (pg16, pg17, pg18). Older versions are deliberately unsupported: RTEPermissionInfo only exists in PG16+, and PG15 would need a second permission-handling path.
 - After fixing crashes, verify OID handling is still correct - these issues are related.
 - Crashes during execution are caused by improper plan construction - debug the plan construction code.
 - AGGREF.args must be a list of TargetEntry nodes in PostgreSQL 14+, not raw Var nodes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ pgrx-tests = "0.19.1"
 
 [features]
 default = ["pg17"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["pgrx-tests/pg_test"]
 
 [package.metadata.pgrx]

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ A PostgreSQL extension written in Rust that enables executing Substrait query pl
 
 ### Prerequisites
 
-- PostgreSQL 13-17
+- PostgreSQL 16-18
 - Rust toolchain
 - cargo-pgrx
 
 ### Building
 
 ```bash
-# Install cargo-pgrx
-cargo install cargo-pgrx
+# Install cargo-pgrx (must match the pgrx version in Cargo.toml)
+cargo install cargo-pgrx --version "=0.19.1"
 
-# Initialize pgrx (replace pg16 with your PostgreSQL version)
-cargo pgrx init --pg16 download
+# Initialize pgrx (replace pg17 with your PostgreSQL version)
+cargo pgrx init --pg17 download
 
 # Build and install the extension
 cargo pgrx install --release
@@ -34,16 +34,16 @@ cargo pgrx install --release
 
 ```bash
 # Install cargo-pgrx if not already installed
-cargo install cargo-pgrx --version "=0.14.3"
+cargo install cargo-pgrx --version "=0.19.1"
 
 # Initialize pgrx with your PostgreSQL version
-cargo pgrx init --pg15 download  # or --pg16, --pg17
+cargo pgrx init --pg17 download  # or --pg16, --pg18
 
 # Start PostgreSQL with the extension loaded
 cargo pgrx run
 
-# In another terminal, connect to the database
-psql -h localhost -p 28815 -d pg_substrait
+# In another terminal, connect to the database (port is 28800 + pg major)
+psql -h localhost -p 28817 -d pg_substrait
 ```
 
 #### Option 2: Using System PostgreSQL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 use pgrx::{pg_extern, pg_guard, pg_sys};
+
+mod pg_compat;
 use prost::Message;
 use std::sync::Mutex;
 use substrait::proto::Plan;
@@ -328,25 +330,12 @@ unsafe fn execute_planned_stmt_as_srf(
 
     let tuplestore = pg_sys::tuplestore_begin_heap(true, false, 1024);
 
-    // Push an active snapshot for the executor
+    // Push an active snapshot for the executor. We use it directly rather
+    // than through CreateQueryDesc: CreateQueryDesc registers its own
+    // snapshot copy that only FreeQueryDesc would release, and we drive the
+    // plan state manually without a QueryDesc.
     pg_sys::PushActiveSnapshot(pg_sys::GetTransactionSnapshot());
-
-    // Create QueryDesc for execution
-    let query_desc = pg_sys::CreateQueryDesc(
-        planned_stmt,
-        std::ptr::null(), // sourceText
-        pg_sys::GetActiveSnapshot(),
-        std::ptr::null_mut(), // crosscheck snapshot
-        std::ptr::null_mut(), // dest
-        std::ptr::null_mut(), // params
-        std::ptr::null_mut(), // queryEnv
-        0,                    // instrument_options
-    );
-
-    if query_desc.is_null() {
-        pg_sys::PopActiveSnapshot();
-        pgrx::error!("Failed to create QueryDesc");
-    }
+    let snapshot = pg_sys::GetActiveSnapshot();
 
     // Skip ExecutorStart and manually initialize (PG17 has stricter requirements).
     let estate = pg_sys::CreateExecutorState();
@@ -358,11 +347,11 @@ unsafe fn execute_planned_stmt_as_srf(
     // Initialize range table from PlannedStmt (using permInfos from standard_planner)
     let rtable = (*planned_stmt).rtable;
     let perminfos = (*planned_stmt).permInfos;
-    pg_sys::ExecInitRangeTable(estate, rtable, perminfos);
+    pg_compat::exec_init_range_table(estate, rtable, perminfos);
 
     // Set up estate with PlannedStmt and snapshot
     (*estate).es_plannedstmt = planned_stmt;
-    (*estate).es_snapshot = (*query_desc).snapshot;
+    (*estate).es_snapshot = snapshot;
 
     // Allocate PARAM_EXEC slots used by SubPlans and InitPlans.
     // This mirrors InitPlan() in the standard executor.
@@ -406,9 +395,6 @@ unsafe fn execute_planned_stmt_as_srf(
         pgrx::error!("ExecInitNode failed to create plan state");
     }
 
-    (*query_desc).estate = estate;
-    (*query_desc).planstate = plan_state;
-
     // Get tuples by calling ExecProcNode on the plan state
     loop {
         let slot = pg_sys::ExecProcNode(plan_state);
@@ -439,25 +425,18 @@ unsafe fn execute_planned_stmt_as_srf(
 
         pg_sys::slot_getallattrs(slot);
 
-        let slot_attrs = if !slot_desc.is_null() {
-            (*slot_desc).attrs.as_ptr()
-        } else {
-            std::ptr::null()
-        };
-        let expected_attrs = (*expected_tupdesc).attrs.as_ptr();
-
         for i in 0..natts_to_copy {
             if (*slot).tts_isnull.add(i as usize).read() {
                 nulls[i as usize] = true;
                 values[i as usize] = pg_sys::Datum::from(0);
             } else {
                 let src_value = (*slot).tts_values.add(i as usize).read();
-                let expected_attr = &*expected_attrs.add(i as usize);
+                let expected_attr = &*pg_compat::tupdesc_attr(expected_tupdesc, i as usize);
                 let expected_type = expected_attr.atttypid;
 
                 // Check if type coercion is needed
-                let src_type = if !slot_attrs.is_null() {
-                    (*slot_attrs.add(i as usize)).atttypid
+                let src_type = if !slot_desc.is_null() {
+                    (*pg_compat::tupdesc_attr(slot_desc, i as usize)).atttypid
                 } else {
                     expected_type // Assume same type if no slot descriptor
                 };
@@ -480,9 +459,14 @@ unsafe fn execute_planned_stmt_as_srf(
         );
     }
 
-    // Cleanup manually since we bypassed ExecutorStart
-    // ExecutorFinish/ExecutorEnd expect structures set up by ExecutorStart
+    // Cleanup manually since we bypassed ExecutorStart. Mirror ExecEndPlan:
+    // end the plan node, drop the tuple table (unpinning scan-slot tuple
+    // descriptors), then close the range-table relations. Without the last
+    // two steps the descriptors and relations leak (pg18 reports "resource
+    // was not closed" warnings at portal shutdown).
     pg_sys::ExecEndNode(plan_state);
+    pg_sys::ExecResetTupleTable((*estate).es_tupleTable, false);
+    pg_sys::ExecCloseRangeTableRelations(estate);
     pg_sys::FreeExecutorState(estate);
     pg_sys::PopActiveSnapshot();
 
@@ -2369,7 +2353,7 @@ mod tests {
 
             // Initialize range table (empty for Result node)
             let empty_perminfos: *mut pg_sys::List = std::ptr::null_mut();
-            pg_sys::ExecInitRangeTable(estate, std::ptr::null_mut(), empty_perminfos);
+            crate::pg_compat::exec_init_range_table(estate, std::ptr::null_mut(), empty_perminfos);
 
             // Set planned statement reference
             (*estate).es_plannedstmt = (*query_desc).plannedstmt;
@@ -2566,7 +2550,11 @@ mod tests {
             // Use CreateExecutorState + ExecInitNode instead of ExecutorStart
             let manual_estate = pg_sys::CreateExecutorState();
             let manual_empty_perminfos: *mut pg_sys::List = std::ptr::null_mut();
-            pg_sys::ExecInitRangeTable(manual_estate, std::ptr::null_mut(), manual_empty_perminfos);
+            crate::pg_compat::exec_init_range_table(
+                manual_estate,
+                std::ptr::null_mut(),
+                manual_empty_perminfos,
+            );
             (*manual_estate).es_plannedstmt = manual_planned_stmt;
             (*manual_estate).es_snapshot = (*manual_query_desc).snapshot;
             (*manual_estate).es_crosscheck_snapshot = std::ptr::null_mut();

--- a/src/pg_compat.rs
+++ b/src/pg_compat.rs
@@ -1,0 +1,71 @@
+//! Small shims over PostgreSQL APIs that changed between supported versions.
+
+use pgrx::pg_sys;
+
+/// Get attribute `i` (0-based) of a tuple descriptor.
+///
+/// PostgreSQL 18 moved the attribute array out of `TupleDescData.attrs`;
+/// access goes through the `TupleDescAttr()` accessor instead.
+#[cfg(any(feature = "pg16", feature = "pg17"))]
+pub(crate) unsafe fn tupdesc_attr(
+    tupdesc: pg_sys::TupleDesc,
+    i: usize,
+) -> *mut pg_sys::FormData_pg_attribute {
+    (*tupdesc).attrs.as_mut_ptr().add(i)
+}
+
+/// Get attribute `i` (0-based) of a tuple descriptor.
+#[cfg(feature = "pg18")]
+pub(crate) unsafe fn tupdesc_attr(
+    tupdesc: pg_sys::TupleDesc,
+    i: usize,
+) -> *mut pg_sys::FormData_pg_attribute {
+    pg_sys::TupleDescAttr(tupdesc, i as i32)
+}
+
+/// Initialize the executor's range table.
+///
+/// PostgreSQL 18 added an `unpruned_relids` parameter tracking which range
+/// table entries survived plan-time partition pruning; none of ours are
+/// pruned, so all of them are unpruned (matching InitPlan()).
+#[cfg(any(feature = "pg16", feature = "pg17"))]
+pub(crate) unsafe fn exec_init_range_table(
+    estate: *mut pg_sys::EState,
+    rtable: *mut pg_sys::List,
+    perminfos: *mut pg_sys::List,
+) {
+    pg_sys::ExecInitRangeTable(estate, rtable, perminfos);
+}
+
+/// Initialize the executor's range table.
+#[cfg(feature = "pg18")]
+pub(crate) unsafe fn exec_init_range_table(
+    estate: *mut pg_sys::EState,
+    rtable: *mut pg_sys::List,
+    perminfos: *mut pg_sys::List,
+) {
+    let n = pg_sys::list_length(rtable);
+    let unpruned_relids = if n > 0 {
+        pg_sys::bms_add_range(std::ptr::null_mut(), 1, n)
+    } else {
+        std::ptr::null_mut()
+    };
+    pg_sys::ExecInitRangeTable(estate, rtable, perminfos, unpruned_relids);
+}
+
+/// Record whether a sort clause's `sortop` is a "greater than" (descending)
+/// operator.
+///
+/// PostgreSQL 18 split the sort direction out of `sortop` into a separate
+/// `reverse_sort` flag (`sortop` is now documented as the '<' operator). On
+/// earlier versions the direction is carried entirely by `sortop`, so this is
+/// a no-op there.
+#[cfg(any(feature = "pg16", feature = "pg17"))]
+pub(crate) unsafe fn set_sort_reverse(_sgc: *mut pg_sys::SortGroupClause, _reverse: bool) {}
+
+/// Record whether a sort clause's `sortop` is a "greater than" (descending)
+/// operator.
+#[cfg(feature = "pg18")]
+pub(crate) unsafe fn set_sort_reverse(sgc: *mut pg_sys::SortGroupClause, reverse: bool) {
+    (*sgc).reverse_sort = reverse;
+}

--- a/src/query_builder/relations.rs
+++ b/src/query_builder/relations.rs
@@ -291,7 +291,7 @@ unsafe fn create_range_table_entry(
         let natts = (*tupdesc).natts;
         let mut colnames: *mut pg_sys::List = std::ptr::null_mut();
         for i in 0..natts {
-            let attr = (*tupdesc).attrs.as_ptr().add(i as usize);
+            let attr = crate::pg_compat::tupdesc_attr(tupdesc, i as usize);
             if !(*attr).attisdropped {
                 let name_ptr = (*attr).attname.data.as_ptr();
                 let name_cstr = std::ffi::CStr::from_ptr(name_ptr);
@@ -340,7 +340,7 @@ unsafe fn get_table_columns(
 
     let mut columns = Vec::new();
     for i in 0..natts {
-        let attr = (*tupdesc).attrs.as_ptr().add(i as usize);
+        let attr = crate::pg_compat::tupdesc_attr(tupdesc, i as usize);
         if (*attr).attisdropped {
             continue;
         }
@@ -1267,11 +1267,14 @@ unsafe fn convert_sort_to_query_parts(
             }
             None => return Err("Sort field has no sort_kind".into()),
         };
-        let (sortop, nulls_first) = match direction {
-            SortDirection::AscNullsFirst => (ltop, true),
-            SortDirection::AscNullsLast | SortDirection::Unspecified => (ltop, false),
-            SortDirection::DescNullsFirst => (gtop, true),
-            SortDirection::DescNullsLast => (gtop, false),
+        // `reverse` marks a descending sort, where `sortop` is a "greater
+        // than" operator. PostgreSQL 18 needs this recorded in a separate
+        // SortGroupClause field; earlier versions encode it in sortop alone.
+        let (sortop, nulls_first, reverse) = match direction {
+            SortDirection::AscNullsFirst => (ltop, true, false),
+            SortDirection::AscNullsLast | SortDirection::Unspecified => (ltop, false, false),
+            SortDirection::DescNullsFirst => (gtop, true, true),
+            SortDirection::DescNullsLast => (gtop, false, true),
             SortDirection::Clustered => {
                 return Err("Clustered sort direction is not supported".into());
             }
@@ -1284,7 +1287,9 @@ unsafe fn convert_sort_to_query_parts(
         sgc.sortop = sortop;
         sgc.nulls_first = nulls_first;
         sgc.hashable = hashable;
-        sort_clause = pg_sys::lappend(sort_clause, sgc.into_pg() as *mut std::ffi::c_void);
+        let sgc = sgc.into_pg();
+        crate::pg_compat::set_sort_reverse(sgc, reverse);
+        sort_clause = pg_sys::lappend(sort_clause, sgc as *mut std::ffi::c_void);
     }
 
     parts.sort_clause = Some(sort_clause);


### PR DESCRIPTION
## Summary

Adds pg16 and pg18 support alongside pg17. A new `src/pg_compat.rs` isolates the three version-specific API differences, each cfg-gated by feature, so the query builder and executor stay version-clean.

### Version differences handled
- **`TupleDescData.attrs` removed in pg18** — use the `TupleDescAttr()` accessor. `tupdesc_attr()` wraps both forms.
- **`ExecInitRangeTable()` gained an `unpruned_relids` argument in pg18** — `exec_init_range_table()` passes all range-table indices (none of ours are plan-time pruned).
- **`SortGroupClause` gained `reverse_sort` in pg18** — DESC is now `sortop = '<'` with `reverse_sort = true` rather than `sortop = '>'` alone. This was the subtle one: without it, **descending `ORDER BY` silently sorted ascending**, so `LIMIT` queries returned the wrong row (10 TPC-H queries failed on pg18, e.g. Q5 returned INDIA instead of VIETNAM). `set_sort_reverse()` records it on pg18 and is a no-op earlier.

### Resource leaks fixed
The manual executor path (`execute_planned_stmt_as_srf`) never fully mirrored `ExecEndPlan`; pg18 surfaces this as `resource was not closed` warnings at portal shutdown. Now during teardown we also:
- `ExecResetTupleTable` — unpins scan-slot tuple descriptors
- `ExecCloseRangeTableRelations` — closes/unlocks the range-table relations
- dropped the unused `CreateQueryDesc`, whose registered snapshot was never released

These were latent on all versions; fixing them removes the warnings and the leaks.

## Testing

`cargo pgrx test pg{16,17,18}`: **51 passed / 0 failed** on each. Clippy clean under `-D warnings` on all three; pre-commit passes. CI now runs a **16/17/18 matrix**.

Note: pg15 and earlier are intentionally out of scope — `RTEPermissionInfo` only exists in pg16+, and pg15 would need a second permission-handling path.